### PR TITLE
chore: remove unused .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,0 @@
-{
-  "mcpServers": {
-    "rinda-cli": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/bin/rinda-cli",
-      "args": ["mcp", "serve"],
-      "env": {}
-    }
-  }
-}


### PR DESCRIPTION
## Summary
- Removes `.mcp.json` which references an unimplemented `rinda-cli mcp serve` command
- The plugin operates via markdown commands/skills/agents in `.claude-plugin/`, not an MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)