### PR TITLE
refactor(cli): rework auth to use refresh token flow

### DIFF
--- a/crates/cli/src/api_helper.rs
+++ b/crates/cli/src/api_helper.rs
@@ -12,7 +12,7 @@ pub async fn get_authenticated_client() -> (rinda_sdk::Client, Credentials) {
     let creds = match load_credentials() {
         Ok(c) => c,
         Err(credentials::CredError::NotLoggedIn) => {
-            eprintln!("Not logged in. Run: rinda auth login");
+            eprintln!("Not logged in. Run: rinda auth url");
             process::exit(1);
         }
         Err(e) => {
@@ -27,7 +27,13 @@ pub async fn get_authenticated_client() -> (rinda_sdk::Client, Credentials) {
         return (client, creds);
     }
 
-    // Token expired or expiring soon — attempt a refresh.
+    // No refresh token — can't refresh, ask user to re-login.
+    if creds.refresh_token.is_empty() {
+        eprintln!("Session expired. Get a new token at: rinda auth url");
+        process::exit(1);
+    }
+
+    // Attempt a refresh.
     let refresh_client = oauth::sdk_client(None);
     let mut body = serde_json::Map::new();
     body.insert(
@@ -41,7 +47,7 @@ pub async fn get_authenticated_client() -> (rinda_sdk::Client, Credentials) {
             let new_token = match resp.get("token").and_then(|v| v.as_str()) {
                 Some(t) => t.to_string(),
                 None => {
-                    eprintln!("Session expired. Run: rinda auth login");
+                    eprintln!("Session expired. Get a new token at: rinda auth url");
                     process::exit(1);
                 }
             };
@@ -72,7 +78,7 @@ pub async fn get_authenticated_client() -> (rinda_sdk::Client, Credentials) {
         Err(e) => {
             let err_str = format!("{e}");
             if err_str.contains("401") || err_str.contains("status code 401") {
-                eprintln!("Session expired. Run: rinda auth login");
+                eprintln!("Session expired. Get a new token at: rinda auth url");
             } else if err_str.contains("connect") || err_str.contains("timeout") {
                 eprintln!("Cannot reach RINDA API. Check your connection.");
             } else {

--- a/crates/cli/src/commands/auth.rs
+++ b/crates/cli/src/commands/auth.rs
@@ -16,10 +16,12 @@ pub struct AuthArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum AuthCommands {
-    /// Log in. Provide a token from https://alpha.rinda.ai/cli-auth, or omit to open browser.
-    Login {
-        /// Bearer token from https://alpha.rinda.ai/cli-auth (optional)
-        token: Option<String>,
+    /// Print the URL to obtain an auth token
+    Url,
+    /// Log in with a refresh token from the auth URL
+    Token {
+        /// Refresh token from https://alpha.rinda.ai/cli-auth
+        token: String,
     },
     /// Check authentication status
     Status,
@@ -62,15 +64,65 @@ fn extract_jwt_claims(token: &str) -> (String, String, String) {
 
 pub async fn run(args: AuthArgs) {
     match args.command {
-        AuthCommands::Login { token: Some(token) } => {
-            // Token-based login: decode JWT claims and store credentials.
-            let (email, workspace_id, user_id) = extract_jwt_claims(&token);
-            let expires_at = extract_exp_from_jwt(&token);
+        AuthCommands::Url => {
+            println!("https://alpha.rinda.ai/cli-auth");
+        }
+
+        AuthCommands::Token { token: refresh_token } => {
+            // Exchange refresh token for an access token.
+            let client = oauth::sdk_client(None);
+            let mut body = serde_json::Map::new();
+            body.insert(
+                "refreshToken".to_string(),
+                serde_json::Value::String(refresh_token.clone()),
+            );
+
+            let resp = match client.post_api_v1_auth_refresh(&body).await {
+                Ok(r) => r.into_inner(),
+                Err(e) => {
+                    eprintln!("Invalid or expired token: {e}");
+                    process::exit(1);
+                }
+            };
+
+            let access_token = match resp.get("token").and_then(|v| v.as_str()) {
+                Some(t) => t.to_string(),
+                None => {
+                    eprintln!("No access token in refresh response");
+                    process::exit(1);
+                }
+            };
+
+            let new_refresh_token = resp
+                .get("refreshToken")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+                .unwrap_or(refresh_token);
+
+            let (email, _, user_id) = extract_jwt_claims(&access_token);
+            let expires_at = extract_exp_from_jwt(&access_token);
+
+            // Fetch workspace ID from the API.
+            let authed_client = oauth::sdk_client(Some(&access_token));
+            let workspace_id = match authed_client.get_api_v1_workspaces_user().await {
+                Ok(resp) => {
+                    let body = resp.into_inner();
+                    body.get("data")
+                        .and_then(|d| d.as_array())
+                        .and_then(|arr| arr.first())
+                        .and_then(|ws| ws.get("id"))
+                        .and_then(|id| id.as_str())
+                        .unwrap_or_default()
+                        .to_string()
+                }
+                Err(_) => String::new(),
+            };
+
             let creds = Credentials {
-                access_token: token,
-                refresh_token: String::new(),
+                access_token,
+                refresh_token: new_refresh_token,
                 expires_at,
-                workspace_id,
+                workspace_id: workspace_id.clone(),
                 user_id,
                 email: email.clone(),
             };
@@ -83,19 +135,14 @@ pub async fn run(args: AuthArgs) {
             } else {
                 println!("Logged in as {email}");
             }
-        }
-
-        AuthCommands::Login { token: None } => {
-            // No token provided: instruct user to visit cli-auth URL.
-            println!("Visit the following URL to obtain your token:");
-            println!("  https://alpha.rinda.ai/cli-auth");
-            println!();
-            println!("Then run: rinda auth login <token>");
+            if !workspace_id.is_empty() {
+                println!("Workspace: {workspace_id}");
+            }
         }
 
         AuthCommands::Status => {
             if !Credentials::exists() {
-                println!("Not logged in. Run: rinda auth login");
+                println!("Not logged in. Run: rinda auth url");
                 return;
             }
             match Credentials::load() {
@@ -152,7 +199,7 @@ async fn ensure_valid() {
     let creds = match load_credentials() {
         Ok(c) => c,
         Err(credentials::CredError::NotLoggedIn) => {
-            eprintln!("Not logged in. Run: rinda auth login");
+            eprintln!("Not logged in. Run: rinda auth url");
             process::exit(1);
         }
         Err(e) => {
@@ -166,7 +213,13 @@ async fn ensure_valid() {
         process::exit(0);
     }
 
-    // Token is expired or expiring soon — attempt a refresh.
+    // No refresh token — can't refresh.
+    if creds.refresh_token.is_empty() {
+        eprintln!("Session expired. Get a new token at: rinda auth url");
+        process::exit(1);
+    }
+
+    // Attempt a refresh.
     let client = oauth::sdk_client(None);
     let mut body = serde_json::Map::new();
     body.insert(
@@ -180,7 +233,7 @@ async fn ensure_valid() {
             let new_token = match resp.get("token").and_then(|v| v.as_str()) {
                 Some(t) => t.to_string(),
                 None => {
-                    eprintln!("Session expired. Run: rinda auth login");
+                    eprintln!("Session expired. Run: rinda auth url");
                     process::exit(1);
                 }
             };
@@ -210,7 +263,7 @@ async fn ensure_valid() {
         Err(e) => {
             let err_str = format!("{e}");
             if err_str.contains("401") || err_str.contains("status code 401") {
-                eprintln!("Session expired. Run: rinda auth login");
+                eprintln!("Session expired. Run: rinda auth url");
                 process::exit(1);
             }
             if err_str.contains("connect") || err_str.contains("timeout") {
@@ -271,7 +324,7 @@ mod tests {
         assert_eq!(user_id, "");
     }
 
-    /// Acceptance criteria: `rinda auth login <token>` should decode the JWT and
+    /// Acceptance criteria: `rinda auth url <token>` should decode the JWT and
     /// extract user info — this test verifies the claim-extraction logic that drives
     /// the token-based login flow described in issue #40.
     #[test]

--- a/crates/cli/src/credentials.rs
+++ b/crates/cli/src/credentials.rs
@@ -73,7 +73,7 @@ impl Credentials {
 /// Error type for credential operations used by ensure-valid flow.
 #[derive(Debug, thiserror::Error)]
 pub enum CredError {
-    #[error("Not logged in. Run: rinda auth login")]
+    #[error("Not logged in. Run: rinda auth url")]
     NotLoggedIn,
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
@@ -97,6 +97,9 @@ pub fn load_credentials_from(path: &Path) -> CredResult<Credentials> {
         .open(&lock_path)
     {
         Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(CredError::NotLoggedIn);
+        }
         Err(e) => return Err(CredError::Io(e)),
     };
     lock_file.lock_shared()?;


### PR DESCRIPTION
## Summary
- Split `auth login` into `auth url` (prints URL) and `auth token` (accepts refresh token)
- `auth token` now exchanges refresh token via `/auth/refresh` for an access token, fetches workspace ID from `/workspaces/user`, and stores both tokens
- Silent token refresh on expiry when refresh token is available; clear error message when not
- Fix crash when `~/.rinda/` directory doesn't exist (lock file creation returned raw IO error instead of "Not logged in")

## Test plan
- [x] `cargo build` — compiles
- [x] `cargo test` — 29 tests pass
- [x] `rinda auth url` — prints URL
- [x] `rinda auth status` — shows correct status
- [x] `rinda auth logout` — works
- [x] All commands show "Not logged in. Run: rinda auth url" when unauthenticated (including when `~/.rinda/` doesn't exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)