### PR TITLE
fix(cli): unwrap API data envelope in auth and refresh flows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "rinda-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "base64",

--- a/crates/cli/src/api_helper.rs
+++ b/crates/cli/src/api_helper.rs
@@ -44,14 +44,18 @@ pub async fn get_authenticated_client() -> (rinda_sdk::Client, Credentials) {
     match refresh_client.post_api_v1_auth_refresh(&body).await {
         Ok(resp) => {
             let resp = resp.into_inner();
-            let new_token = match resp.get("token").and_then(|v| v.as_str()) {
+            let data = resp
+                .get("data")
+                .and_then(|v| v.as_object())
+                .unwrap_or(&resp);
+            let new_token = match data.get("token").and_then(|v| v.as_str()) {
                 Some(t) => t.to_string(),
                 None => {
                     eprintln!("Session expired. Get a new token at: rinda auth url");
                     process::exit(1);
                 }
             };
-            let new_refresh_token = resp
+            let new_refresh_token = data
                 .get("refreshToken")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string())

--- a/crates/cli/src/commands/auth.rs
+++ b/crates/cli/src/commands/auth.rs
@@ -87,7 +87,13 @@ pub async fn run(args: AuthArgs) {
                 }
             };
 
-            let access_token = match resp.get("token").and_then(|v| v.as_str()) {
+            // The API wraps the payload in a `data` envelope.
+            let data = resp
+                .get("data")
+                .and_then(|v| v.as_object())
+                .unwrap_or(&resp);
+
+            let access_token = match data.get("token").and_then(|v| v.as_str()) {
                 Some(t) => t.to_string(),
                 None => {
                     eprintln!("No access token in refresh response");
@@ -95,7 +101,7 @@ pub async fn run(args: AuthArgs) {
                 }
             };
 
-            let new_refresh_token = resp
+            let new_refresh_token = data
                 .get("refreshToken")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string())
@@ -232,14 +238,18 @@ async fn ensure_valid() {
     match client.post_api_v1_auth_refresh(&body).await {
         Ok(resp) => {
             let resp = resp.into_inner();
-            let new_token = match resp.get("token").and_then(|v| v.as_str()) {
+            let data = resp
+                .get("data")
+                .and_then(|v| v.as_object())
+                .unwrap_or(&resp);
+            let new_token = match data.get("token").and_then(|v| v.as_str()) {
                 Some(t) => t.to_string(),
                 None => {
                     eprintln!("Session expired. Run: rinda auth url");
                     process::exit(1);
                 }
             };
-            let new_refresh_token = resp
+            let new_refresh_token = data
                 .get("refreshToken")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string())

--- a/crates/cli/src/oauth.rs
+++ b/crates/cli/src/oauth.rs
@@ -113,13 +113,19 @@ pub async fn run_oauth_flow() -> Result<Credentials> {
         .map_err(|e| RindaError::Auth(format!("Token exchange failed: {e}")))?
         .into_inner();
 
-    let access_token = callback_resp
+    // The API wraps the payload in a `data` envelope.
+    let data = callback_resp
+        .get("data")
+        .and_then(|v| v.as_object())
+        .unwrap_or(&callback_resp);
+
+    let access_token = data
         .get("token")
         .and_then(|v| v.as_str())
         .ok_or_else(|| RindaError::Auth("No access token in callback response".into()))?
         .to_string();
 
-    let refresh_token = callback_resp
+    let refresh_token = data
         .get("refreshToken")
         .and_then(|v| v.as_str())
         .unwrap_or_default()
@@ -134,23 +140,30 @@ pub async fn run_oauth_flow() -> Result<Credentials> {
 
     // Fetch user profile with the new token.
     let authed_client = sdk_client(Some(&access_token));
-    let profile = authed_client
+    let profile_resp = authed_client
         .get_api_v1_auth_me()
         .await
         .map_err(|e| RindaError::Auth(format!("Failed to fetch user profile: {e}")))?
         .into_inner();
 
-    let email = profile
+    // Response shape: { data: { user: { id, email, ... } } }
+    let user = profile_resp
+        .get("data")
+        .and_then(|d| d.get("user"))
+        .cloned()
+        .unwrap_or(serde_json::Value::Object(profile_resp.clone()));
+
+    let email = user
         .get("email")
         .and_then(|v| v.as_str())
         .unwrap_or_default()
         .to_string();
-    let user_id = profile
+    let user_id = user
         .get("id")
         .and_then(|v| v.as_str())
         .unwrap_or_default()
         .to_string();
-    let workspace_id = profile
+    let workspace_id = user
         .get("workspaceId")
         .and_then(|v| v.as_str())
         .unwrap_or_default()


### PR DESCRIPTION
## Summary
- The RINDA API wraps all responses in a `{ success, data: {...} }` envelope
- CLI was reading `token` and `refreshToken` from the top level, causing all auth flows to fail
- Fixed in `auth.rs`, `api_helper.rs`, and `oauth.rs` to unwrap from `data` first
- Also fixed `/auth/me` profile parsing to read from `data.user`

## Test plan
- [x] `rinda auth logout` → `rinda auth url` → `rinda auth token <token>` — logs in successfully
- [x] `rinda auth status` — shows valid token
- [x] `rinda auth ensure-valid` (valid token) — exits 0
- [x] `rinda auth ensure-valid` (expired token) — refreshes and saves new tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)