### PR TITLE
feat(cli): add install script and document API status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target
 credentials.json
 .env
+bin/rinda-cli

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Download the rinda-cli binary from GitHub Releases.
+# Detects OS/arch and fetches the version pinned in .release-please-manifest.json.
+set -euo pipefail
+
+REPO="FINGU-GRINDA/claude-rinda-plugin"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MANIFEST="$PLUGIN_ROOT/.release-please-manifest.json"
+BINARY="$SCRIPT_DIR/rinda-cli"
+
+# Read pinned version from manifest.
+if [ ! -f "$MANIFEST" ]; then
+  echo "error: .release-please-manifest.json not found" >&2
+  exit 1
+fi
+
+VERSION=$(python3 -c "import json; print(json.load(open('$MANIFEST'))['crates/cli'])" 2>/dev/null \
+  || node -e "console.log(JSON.parse(require('fs').readFileSync('$MANIFEST','utf8'))['crates/cli'])" 2>/dev/null)
+
+if [ -z "$VERSION" ]; then
+  echo "error: could not read version from manifest" >&2
+  exit 1
+fi
+
+TAG="rinda-cli-v${VERSION}"
+
+# Skip download if correct version already exists.
+if [ -x "$BINARY" ]; then
+  CURRENT=$("$BINARY" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
+  if [ "$CURRENT" = "$VERSION" ]; then
+    exit 0
+  fi
+fi
+
+# Detect OS.
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "$OS" in
+  Linux)   ARTIFACT="rinda-cli-linux" ;;
+  Darwin)  ARTIFACT="rinda-cli-macos" ;;
+  MINGW*|MSYS*|CYGWIN*) ARTIFACT="rinda-cli-windows" ;;
+  *) echo "error: unsupported OS: $OS" >&2; exit 1 ;;
+esac
+
+# Detect architecture.
+case "$ARCH" in
+  x86_64|amd64)  ARTIFACT="${ARTIFACT}-x64" ;;
+  aarch64|arm64) ARTIFACT="${ARTIFACT}-arm64" ;;
+  *) echo "error: unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+# Windows binary has .exe suffix.
+case "$OS" in
+  MINGW*|MSYS*|CYGWIN*) ARTIFACT="${ARTIFACT}.exe" ;;
+esac
+
+URL="https://github.com/${REPO}/releases/download/${TAG}/${ARTIFACT}"
+
+echo "Downloading rinda-cli v${VERSION} for ${OS}/${ARCH}..."
+if command -v curl >/dev/null 2>&1; then
+  curl -fSL --retry 3 -o "$BINARY" "$URL"
+elif command -v wget >/dev/null 2>&1; then
+  wget -q -O "$BINARY" "$URL"
+else
+  echo "error: curl or wget required" >&2
+  exit 1
+fi
+
+chmod +x "$BINARY"
+echo "Installed rinda-cli v${VERSION} to $BINARY"

--- a/doc/CLI_API_STATUS.md
+++ b/doc/CLI_API_STATUS.md
@@ -1,0 +1,54 @@
+# CLI API Endpoint Status
+
+Tested on 2026-03-10 against `alpha.rinda.ai`.
+
+## Working
+
+| CLI Command | API Endpoint | Method | Notes |
+|---|---|---|---|
+| `auth url` | — | — | Returns hardcoded URL |
+| `auth token <token>` | `POST /api/v1/auth/refresh` | POST | Exchanges refresh token for access token. Response wrapped in `data` envelope. |
+| `auth status` | — | — | Reads local credentials file |
+| `auth logout` | — | — | Deletes local credentials file |
+| `auth ensure-valid` | `POST /api/v1/auth/refresh` | POST | Auto-refreshes expired access token using stored refresh token |
+| `campaign stats` | `GET /api/v1/dashboard/stats` | GET | Params: `startDate`, `endDate`. Returns lead/email/open-rate stats. |
+| `reply check` | `GET /api/v1/email-replies` | GET | Params: `limit`, `offset`, `isRead`, `sentiment`, etc. Returns reply list. |
+| `order history` | `GET /api/v1/leads/search` | GET | Many filter params. Returns paginated lead list. Works as order-history approximation. |
+
+## Broken
+
+| CLI Command | API Endpoint | Method | Issue |
+|---|---|---|---|
+| `buyer search` | `POST /api/v1/lead-discovery/search` | POST | Returns 422. Endpoint is SSE-streaming conversational AI search. OpenAPI spec has empty `requestBody.content: {}` — no schema. Required fields unknown. |
+| `buyer enrich` | `POST /api/v1/lead-discovery/enrich` | POST | Untested but likely same issue — empty schema in spec. |
+
+## Not Tested (Destructive)
+
+| CLI Command | API Endpoint | Method | Notes |
+|---|---|---|---|
+| `email send` | `POST /api/v1/emails/send` | POST | Sends real email — skipped to avoid side effects |
+| `sequence create` | `POST /api/v1/sequences` | POST | Creates real sequence |
+| `sequence add-contact` | `POST /api/v1/sequences/{id}/enrollments` | POST | Enrolls lead in sequence |
+
+## API Response Envelope
+
+All RINDA API responses are wrapped in a standard envelope:
+
+```json
+{
+  "success": true,
+  "code": "S200",
+  "message": "...",
+  "data": { ... },
+  "timestamp": "2026-03-10T09:50:06.155Z"
+}
+```
+
+The CLI must read from `data`, not from the top-level response object.
+
+## Alternative Endpoints for Buyer Search
+
+The `lead-discovery/search` endpoint is designed for the web UI's conversational AI search flow (SSE streaming). For a CLI-friendly buyer search, consider:
+
+- `GET /api/v1/leads/search` — simple paginated search with filters (already used by `order history`). Supports: `search`, `country`, `businessType`, `leadStatus`, `sortField`, `sortOrder`, `limit`, `offset`, etc.
+- `POST /api/v1/admin/buyer-search/start` — admin buyer search (also returns 422, schema unknown).

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/rinda-cli auth ensure-valid"
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/install.sh && ${CLAUDE_PLUGIN_ROOT}/bin/rinda-cli auth ensure-valid"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Add `bin/install.sh` to auto-download the correct CLI binary from GitHub Releases on first run
- Detects OS (Linux/macOS/Windows) and architecture (x64/arm64)
- Version pinned to `.release-please-manifest.json` so plugin always gets the matching CLI version
- Hook chains install before auth check: `install.sh && rinda-cli auth ensure-valid`
- Add `doc/CLI_API_STATUS.md` documenting which CLI commands work and which API endpoints are broken

## Test plan
- [ ] Verify install.sh downloads correct binary after next release
- [ ] Verify hook runs install + auth on first plugin tool use

🤖 Generated with [Claude Code](https://claude.com/claude-code)