### PR TITLE
fix(ci): use component-scoped release-please output keys

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,8 +16,8 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
+      release_created: ${{ steps.release.outputs['crates/cli--release_created'] }}
+      tag_name: ${{ steps.release.outputs['crates/cli--tag_name'] }}
     steps:
       - id: release
         uses: googleapis/release-please-action@v4


### PR DESCRIPTION
## Summary
- release-please uses path-escaped output keys for multi-package repos (`crates/cli--release_created` instead of `release_created`)
- This caused binary build and upload jobs to always be skipped
- Fixes the output key references so binary builds trigger on release

## Test plan
- [ ] Merge this PR, then merge the release-please PR → verify binary build jobs run

🤖 Generated with [Claude Code](https://claude.com/claude-code)