### PR TITLE
fix(cli): track extra-files in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,10 @@
     "crates/cli": {
       "component": "rinda-cli",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        "bin/install.sh"
+      ]
     }
   },
   "separate-pull-requests": false


### PR DESCRIPTION
## Summary
- Add `bin/install.sh` to release-please `extra-files` for version tracking
- This commit touches `crates/cli` path (via release-please-config.json being in repo root... actually it's in root)

Mainly triggers a new release so the fixed CI workflow (component-scoped output keys) can build binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)