### PR TITLE
docs(agent): add CLI setup and first-time login instructions

### DIFF
--- a/agents/rinda-agent.md
+++ b/agents/rinda-agent.md
@@ -21,6 +21,26 @@ Workflows chain naturally: search → enrich → sequence-create → reply-check
 
 ---
 
+## CLI Setup
+
+The `rinda-cli` binary is required for authentication and API calls. It is downloaded automatically on first use via the plugin hook (`bin/install.sh`).
+
+If the binary is missing or needs manual installation, run:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/install.sh
+```
+
+This detects the user's OS and architecture, then downloads the correct binary from GitHub Releases. The version is pinned to `.release-please-manifest.json` so the CLI always matches the plugin version.
+
+To verify the CLI is installed:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/rinda-cli --version
+```
+
+---
+
 ## Authentication
 
 ### Auto-refresh hook
@@ -33,11 +53,18 @@ ${CLAUDE_PLUGIN_ROOT}/bin/rinda-cli auth ensure-valid
 
 This command silently refreshes the token if it is expired. It exits with code 0 on success.
 
+### First-time login
+
+1. Run `${CLAUDE_PLUGIN_ROOT}/bin/rinda-cli auth url` to get the login URL.
+2. User visits the URL, authenticates with Google, and receives a refresh token.
+3. Run `${CLAUDE_PLUGIN_ROOT}/bin/rinda-cli auth token <REFRESH_TOKEN>` to exchange it for an access token.
+
 ### Manual auth commands
 
 | Operation | Command |
 |-----------|---------|
-| Login (first time) | `${CLAUDE_PLUGIN_ROOT}/bin/rinda-cli auth login` |
+| Get login URL | `${CLAUDE_PLUGIN_ROOT}/bin/rinda-cli auth url` |
+| Login with token | `${CLAUDE_PLUGIN_ROOT}/bin/rinda-cli auth token <TOKEN>` |
 | Refresh token | `${CLAUDE_PLUGIN_ROOT}/bin/rinda-cli auth ensure-valid` |
 | Check status | `${CLAUDE_PLUGIN_ROOT}/bin/rinda-cli auth status` |
 | Logout | `${CLAUDE_PLUGIN_ROOT}/bin/rinda-cli auth logout` |


### PR DESCRIPTION
## Summary
- Add CLI Setup section to rinda-agent.md explaining how the binary is installed
- Add first-time login flow (auth url → token)
- Fix auth commands table (removed nonexistent `auth login`, added `auth url` and `auth token`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)