### PR TITLE
fix(ci): use generic updater for Cargo.toml in release-please

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rinda-cli"
-version = "0.1.3"
+version = "0.1.3" # x-release-please-version
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,11 +7,7 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [
-        {
-          "type": "toml",
-          "path": "crates/cli/Cargo.toml",
-          "key": "package.version"
-        },
+        "crates/cli/Cargo.toml",
         {
           "type": "json",
           "path": ".claude-plugin/plugin.json",


### PR DESCRIPTION
## Summary
- The `toml` type is not supported in release-please extra-files, causing the action to fail
- Switch to generic updater with `x-release-please-version` marker in Cargo.toml

## Test plan
- [ ] Verify release-please action succeeds and creates a release PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release management configuration for improved version tracking automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->