### PR TITLE
perf(ci): build only linux in CI, full matrix in release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,53 +50,18 @@ jobs:
         run: cargo test --workspace
 
   build:
-    name: Build (${{ matrix.target }})
+    name: Build (linux-x64)
     needs: check
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-            artifact: rinda-cli-linux-x64
-          - target: x86_64-apple-darwin
-            os: macos-latest
-            artifact: rinda-cli-macos-x64
-          - target: aarch64-apple-darwin
-            os: macos-latest
-            artifact: rinda-cli-macos-arm64
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-            artifact: rinda-cli-windows-x64.exe
-
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Rust stable toolchain
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.target }}
 
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }} -p rinda-cli
-
-      - name: Rename binary (Unix)
-        if: runner.os != 'Windows'
-        run: mv target/${{ matrix.target }}/release/rinda ${{ matrix.artifact }}
-
-      - name: Rename binary (Windows)
-        if: runner.os == 'Windows'
-        run: mv target/${{ matrix.target }}/release/rinda.exe ${{ matrix.artifact }}
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.artifact }}
-          path: ${{ matrix.artifact }}
+        run: cargo build --release -p rinda-cli


### PR DESCRIPTION
## Summary
- CI was building all 5 targets (linux, macOS x2, Windows) on every PR — slow and unnecessary
- Now CI only builds linux-x64 to verify compilation
- Full cross-platform matrix remains in the release-please workflow for actual releases

## Test plan
- [ ] Verify CI passes with only the linux build job

🤖 Generated with [Claude Code](https://claude.com/claude-code)