### PR TITLE
fix(mcp): serve MCP endpoint at root path instead of /mcp

### DIFF
--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -419,8 +419,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/oauth/token", axum::routing::post(oauth::token))
         .route("/oauth/register", axum::routing::post(oauth::register))
         .with_state(oauth_state.clone())
-        .nest_service(
-            "/mcp",
+        .fallback_service(
             tower::ServiceBuilder::new()
                 .layer(axum::middleware::from_fn_with_state(
                     oauth_state,

--- a/crates/mcp-server/tests/integration.rs
+++ b/crates/mcp-server/tests/integration.rs
@@ -98,7 +98,7 @@ async fn test_initialize_and_list_tools_http() {
     let (port, mut child) = spawn_binary_server().await;
 
     let client = reqwest::Client::new();
-    let base = format!("http://127.0.0.1:{port}/mcp");
+    let base = format!("http://127.0.0.1:{port}");
 
     // ── 1. Send initialize request ────────────────────────────────────────────
     let init_body = serde_json::json!({


### PR DESCRIPTION
## Summary
- Changed MCP Streamable HTTP service from `nest_service("/mcp", ...)` to `fallback_service(...)` so it serves at the root path
- Server URL can now be just the subdomain (e.g. `alpha-mcp.rinda.ai`) without `/mcp` suffix
- Explicit routes (`/health`, `/oauth/*`, `/.well-known/*`) still take priority via exact route matching

## Test plan
- [x] All 48 unit + integration tests pass
- [x] Integration test updated to use root path `/` instead of `/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the MCP Streamable HTTP endpoint at the root path instead of `/mcp`, so clients can use the bare subdomain (e.g., alpha-mcp.rinda.ai). Explicit routes (`/health`, `/oauth/*`, `/.well-known/*`) still take priority.

- **Migration**
  - Update client configs to use the root path `/`; `/mcp` is no longer required.

<sup>Written for commit ed5c94d470830539526c633454eb0dc2dfb12bed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

