### PR TITLE
fix(mcp): remove redundant rinda_auth_login tool

### DIFF
--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -164,13 +164,6 @@ impl RindaMcpServer {
     }
 
     #[tool(
-        description = "Return the browser login URL and instructions to authenticate with RINDA. Use this when not logged in."
-    )]
-    async fn rinda_auth_login(&self, Parameters(_): Parameters<EmptyParams>) -> String {
-        tools::auth::auth_login().await
-    }
-
-    #[tool(
         description = "Start an async buyer search. Returns sessionId for polling. Params: industry, countries (comma-separated codes), buyer_type, min_revenue (USD), limit."
     )]
     async fn rinda_buyer_search(

--- a/crates/mcp-server/src/tools/auth.rs
+++ b/crates/mcp-server/src/tools/auth.rs
@@ -1,4 +1,4 @@
-// Auth tool implementations: rinda_auth_status, rinda_auth_login.
+// Auth tool implementations: rinda_auth_status.
 
 use crate::auth;
 
@@ -78,40 +78,9 @@ pub async fn auth_status(parts: Option<&http::request::Parts>) -> String {
     }
 }
 
-/// Implementation for the rinda_auth_login tool.
-/// Returns instructions for authenticating via the MCP OAuth 2.0 flow.
-/// Authentication is handled automatically by the MCP client (e.g. Claude Desktop)
-/// through the server's OAuth endpoints.
-pub async fn auth_login() -> String {
-    serde_json::json!({
-        "instructions": "Authentication is handled automatically by your MCP client (e.g. Claude Desktop) via the OAuth 2.0 flow. If you are not yet authenticated, your client should prompt you to sign in with Google automatically when you try to use any Rinda tool. You can check your current auth status using the rinda_auth_status tool. Do NOT visit the /oauth/authorize URL directly — it requires parameters that only the MCP client provides."
-    })
-    .to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Acceptance criteria: rinda_auth_login should return a URL and instructions
-    /// without requiring credentials (works when not authenticated).
-    #[tokio::test]
-    async fn auth_login_returns_instructions() {
-        let result = auth_login().await;
-        let parsed: serde_json::Value =
-            serde_json::from_str(&result).expect("should return valid JSON");
-
-        // Should NOT include a direct auth_url (users should not visit it directly)
-        assert!(
-            parsed.get("auth_url").is_none(),
-            "should not include auth_url to avoid users visiting it directly"
-        );
-
-        let instructions = parsed["instructions"]
-            .as_str()
-            .expect("should have instructions");
-        assert!(!instructions.is_empty(), "instructions should not be empty");
-    }
 
     /// Acceptance criteria: rinda_auth_status should return authenticated=false with
     /// a clear message when no parts/token are provided.
@@ -165,14 +134,6 @@ mod tests {
         );
         assert_eq!(parsed["email"].as_str(), Some("test@example.com"));
         assert_eq!(parsed["workspace_id"].as_str(), Some("ws-test"));
-    }
-
-    /// Auth login response should be parseable as JSON regardless of environment.
-    #[tokio::test]
-    async fn auth_login_response_is_valid_json() {
-        let result = auth_login().await;
-        let parsed: Result<serde_json::Value, _> = serde_json::from_str(&result);
-        assert!(parsed.is_ok(), "auth_login should always return valid JSON");
     }
 
     /// Acceptance criteria from issue #82: auth_status should work from Bearer token

--- a/crates/mcp-server/tests/integration.rs
+++ b/crates/mcp-server/tests/integration.rs
@@ -91,7 +91,7 @@ async fn test_health_endpoint() {
     let _ = child.wait().await;
 }
 
-/// Acceptance criteria: MCP server exposes all 15 tools over HTTP transport
+/// Acceptance criteria: MCP server exposes all 14 tools over HTTP transport
 /// (from issue #81: "convert MCP server from stdio to remote HTTP transport")
 #[tokio::test]
 async fn test_initialize_and_list_tools_http() {
@@ -243,12 +243,12 @@ async fn test_initialize_and_list_tools_http() {
     let tool_list = tools.as_array().unwrap();
     assert_eq!(
         tool_list.len(),
-        15,
-        "tools list should have 15 tools, got: {}",
+        14,
+        "tools list should have 14 tools, got: {}",
         tool_list.len()
     );
 
-    // Verify all 15 expected tool names are present
+    // Verify all 14 expected tool names are present
     let tool_names: Vec<&str> = tool_list
         .iter()
         .filter_map(|t| t["name"].as_str())
@@ -256,7 +256,6 @@ async fn test_initialize_and_list_tools_http() {
 
     let expected_tools = [
         "rinda_auth_status",
-        "rinda_auth_login",
         "rinda_buyer_search",
         "rinda_buyer_status",
         "rinda_buyer_results",


### PR DESCRIPTION
## Summary
- Remove `rinda_auth_login` tool — login is handled automatically by the OAuth 2.0 Connect button flow
- Remove associated `auth_login()` function and tests
- Update integration test: 15 → 14 tools

## Test plan
- [x] All 52 tests pass (`cargo test -p rinda-mcp`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the redundant `rinda_auth_login` MCP tool and relies on the OAuth Connect flow for authentication. This simplifies auth and keeps the tool list accurate.

- **Refactors**
  - Deleted `rinda_auth_login` tool and `auth_login()` implementation.
  - Removed related unit tests; kept `rinda_auth_status` tests.
  - Updated HTTP integration test: tools count 15 → 14; removed login tool from expected list.
  - No behavior change; OAuth 2.0 login still happens automatically via the Connect button.

<sup>Written for commit 74416a1191b80923853a92d9834e7d373f230293. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

