### PR TITLE
fix(mcp,cli): forward steps in sequence create, fail-fast on empty workspace, verify creation

### DIFF
--- a/crates/cli/src/commands/sequence.rs
+++ b/crates/cli/src/commands/sequence.rs
@@ -23,11 +23,13 @@ pub enum SequenceCommands {
         #[arg(long)]
         name: String,
 
-        /// Sequence type (e.g. "email", "linkedin")
+        /// Sequence type forwarded as description (e.g. "email", "linkedin")
         #[arg(long, name = "type")]
         seq_type: Option<String>,
 
-        /// JSON array of steps (e.g. '[{"delay":1,"template":"intro"}]')
+        /// JSON array of steps (e.g. '[{"delay":1,"subject":"Hello","body":"..."}]')
+        /// Each element may include: delay/delayDays, subject/emailSubject,
+        /// body/emailBodyText, bodyHtml/emailBodyHtml, stepOrder.
         #[arg(long)]
         steps: Option<String>,
     },
@@ -68,8 +70,8 @@ pub async fn run(args: SequenceArgs) {
     match args.command {
         SequenceCommands::Create {
             name,
-            seq_type: _seq_type,
-            steps: _steps,
+            seq_type,
+            steps,
         } => {
             let workspace_id = require_workspace_id(&creds);
             let name_typed: rinda_sdk::types::PostApiV1SequencesBodyName =
@@ -78,13 +80,16 @@ pub async fn run(args: SequenceArgs) {
                     process::exit(1);
                 });
 
+            // Forward seq_type via the description field.
+            let description = seq_type.map(|t| format!("Type: {t}"));
+
             let body = rinda_sdk::types::PostApiV1SequencesBody {
                 name: name_typed,
                 workspace_id,
                 created_by: None,
                 customer_group_id: None,
                 customer_group_ids: Vec::new(),
-                description: None,
+                description,
                 memo: None,
                 personalization_config: None,
                 personalization_mode: None,
@@ -93,9 +98,149 @@ pub async fn run(args: SequenceArgs) {
                 workflow_data: None,
             };
 
-            match client.post_api_v1_sequences(&body).await {
-                Ok(resp) => print_json(&resp.into_inner()),
+            let sequence_resp = match client.post_api_v1_sequences(&body).await {
+                Ok(resp) => resp.into_inner(),
                 Err(e) => exit_api_error("sequence create failed", e),
+            };
+
+            // Extract the created sequence ID for step creation and verification.
+            let sequence_id_str = sequence_resp
+                .get("id")
+                .or_else(|| sequence_resp.get("data").and_then(|d| d.get("id")))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+
+            if sequence_id_str.is_none() {
+                eprintln!(
+                    "Warning: sequence ID not found in API response — verify creation with: rinda-cli sequence list"
+                );
+            }
+
+            // If no steps provided, print the create response and exit.
+            let Some(steps_json) = steps else {
+                print_json(&sequence_resp);
+                if let Some(id) = &sequence_id_str {
+                    eprintln!("Sequence created with ID: {id}");
+                    eprintln!(
+                        "Tip: run `rinda-cli sequence generate --id {id}` to AI-generate email steps."
+                    );
+                }
+                process::exit(0);
+            };
+
+            // Parse the sequence ID UUID needed to create steps.
+            let seq_uuid = match sequence_id_str.as_deref().unwrap_or("").parse::<Uuid>() {
+                Ok(u) => u,
+                Err(_) => {
+                    eprintln!(
+                        "Sequence was created but its ID could not be parsed as UUID; cannot add steps."
+                    );
+                    eprintln!("Verify with: rinda-cli sequence list");
+                    print_json(&sequence_resp);
+                    process::exit(1);
+                }
+            };
+
+            // Parse the JSON steps array.
+            let parsed_steps: serde_json::Value =
+                serde_json::from_str(&steps_json).unwrap_or_else(|e| {
+                    eprintln!("Invalid steps JSON: {e}");
+                    process::exit(1);
+                });
+
+            let step_array = match parsed_steps.as_array() {
+                Some(a) => a.clone(),
+                None => {
+                    eprintln!("--steps must be a JSON array.");
+                    process::exit(1);
+                }
+            };
+
+            println!(
+                "Sequence created with ID: {}",
+                sequence_id_str.as_deref().unwrap_or("unknown")
+            );
+            println!("Creating {} step(s)...", step_array.len());
+
+            let mut all_ok = true;
+            for (idx, step) in step_array.iter().enumerate() {
+                let step_order_num = step
+                    .get("stepOrder")
+                    .or_else(|| step.get("step_order"))
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or((idx + 1) as f64);
+
+                let delay_days_num = step
+                    .get("delayDays")
+                    .or_else(|| step.get("delay"))
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(1.0);
+
+                let subject_str = step
+                    .get("emailSubject")
+                    .or_else(|| step.get("subject"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("(no subject)");
+
+                let body_text = step
+                    .get("emailBodyText")
+                    .or_else(|| step.get("body"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+
+                let body_html = step
+                    .get("emailBodyHtml")
+                    .or_else(|| step.get("bodyHtml"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+
+                let subject_typed: rinda_sdk::types::PostApiV1SequencesByIdStepsBodyEmailSubject =
+                    subject_str.parse().unwrap_or_else(|e| {
+                        eprintln!("Step {}: invalid email subject: {e}", idx + 1);
+                        process::exit(1);
+                    });
+
+                let step_body = rinda_sdk::types::PostApiV1SequencesByIdStepsBody {
+                    delay_days: rinda_sdk::types::PostApiV1SequencesByIdStepsBodyDelayDays::Number(
+                        delay_days_num,
+                    ),
+                    email_body_html: body_html,
+                    email_body_text: body_text,
+                    email_subject: subject_typed,
+                    email_template_id: None,
+                    files: Vec::new(),
+                    generation_source: None,
+                    original_email_body_html: None,
+                    original_email_body_text: None,
+                    original_email_subject: None,
+                    original_language: None,
+                    scheduled_hour: None,
+                    scheduled_minute: None,
+                    step_order: rinda_sdk::types::PostApiV1SequencesByIdStepsBodyStepOrder::Number(
+                        step_order_num,
+                    ),
+                    timezone: None,
+                    translated_language: None,
+                };
+
+                match client
+                    .post_api_v1_sequences_by_id_steps(&seq_uuid, &step_body)
+                    .await
+                {
+                    Ok(resp) => {
+                        println!("Step {} created.", idx + 1);
+                        print_json(&resp.into_inner());
+                    }
+                    Err(e) => {
+                        eprintln!("Step {} failed: {e}", idx + 1);
+                        all_ok = false;
+                    }
+                }
+            }
+
+            if !all_ok {
+                eprintln!("One or more steps failed. Verify with: rinda-cli sequence list");
+                process::exit(1);
             }
         }
 

--- a/crates/mcp-server/src/tools/sequence.rs
+++ b/crates/mcp-server/src/tools/sequence.rs
@@ -4,14 +4,31 @@ use uuid::Uuid;
 
 use crate::auth::{AuthContext, json_to_text, sdk_client};
 
-/// Create a new email sequence.
+/// Create a new email sequence, optionally with inline steps.
+///
+/// `seq_type` — forwarded as the sequence `description` field (e.g. "email").
+/// `steps`    — JSON array of step objects. Supported fields per element:
+///   - `delay` or `delayDays` (number): days to wait before sending (default 1)
+///   - `subject` or `emailSubject` (string): email subject line (required per step)
+///   - `body` or `emailBodyText` (string): plain-text email body (optional)
+///   - `bodyHtml` or `emailBodyHtml` (string): HTML email body (optional)
+///   - `stepOrder` (number): explicit step ordering (defaults to 1-based index)
+///
+/// After the sequence is created, each step is added via the steps API.
+/// The response includes the created sequence ID and per-step results.
 pub async fn sequence_create(
     auth: &AuthContext,
     name: String,
     seq_type: Option<String>,
     steps: Option<String>,
 ) -> String {
-    let _ = (seq_type, steps); // currently unused — SDK doesn't expose these directly
+    // Fail fast on empty workspace_id — avoids a confusing UUID parse error later.
+    if auth.workspace_id.is_empty() {
+        return serde_json::json!({
+            "error": "No workspace ID found in your authentication token. Please re-authenticate or ensure your account has an active workspace."
+        })
+        .to_string();
+    }
 
     let client = sdk_client(Some(&auth.access_token));
 
@@ -19,7 +36,10 @@ pub async fn sequence_create(
         Ok(u) => u,
         Err(_) => {
             return serde_json::json!({
-                "error": "Invalid workspace ID in token. Please re-authenticate."
+                "error": format!(
+                    "Workspace ID '{}' in your token is not a valid UUID. Please re-authenticate.",
+                    auth.workspace_id
+                )
             })
             .to_string();
         }
@@ -33,13 +53,16 @@ pub async fn sequence_create(
         }
     };
 
+    // Forward seq_type via the description field.
+    let description = seq_type.map(|t| format!("Type: {t}"));
+
     let body = rinda_sdk::types::PostApiV1SequencesBody {
         name: name_typed,
         workspace_id,
         created_by: None,
         customer_group_id: None,
         customer_group_ids: Vec::new(),
-        description: None,
+        description,
         memo: None,
         personalization_config: None,
         personalization_mode: None,
@@ -48,12 +71,176 @@ pub async fn sequence_create(
         workflow_data: None,
     };
 
-    match client.post_api_v1_sequences(&body).await {
-        Ok(resp) => json_to_text(&resp.into_inner()),
+    let sequence_resp = match client.post_api_v1_sequences(&body).await {
+        Ok(resp) => resp.into_inner(),
         Err(e) => {
-            serde_json::json!({ "error": format!("sequence create failed: {e}") }).to_string()
+            return serde_json::json!({ "error": format!("sequence create failed: {e}") })
+                .to_string();
+        }
+    };
+
+    // Extract the created sequence ID for verification and step creation.
+    let sequence_id_str = sequence_resp
+        .get("id")
+        .or_else(|| sequence_resp.get("data").and_then(|d| d.get("id")))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    // If no steps were provided, return the create response immediately.
+    let Some(steps_json) = steps else {
+        let mut result = serde_json::json!({
+            "sequence": sequence_resp,
+            "sequence_id": sequence_id_str,
+            "steps_created": [],
+            "message": "Sequence created successfully. No inline steps provided; call rinda_sequence_generate to AI-generate steps."
+        });
+        if sequence_id_str.is_none() {
+            result["warning"] = serde_json::Value::String(
+                "Sequence ID not found in API response — verify creation with rinda_sequence_list."
+                    .to_string(),
+            );
+        }
+        return result.to_string();
+    };
+
+    // Parse the sequence ID UUID needed to create steps.
+    let seq_uuid = match sequence_id_str.as_deref().unwrap_or("").parse::<Uuid>() {
+        Ok(u) => u,
+        Err(_) => {
+            return serde_json::json!({
+                "sequence": sequence_resp,
+                "sequence_id": sequence_id_str,
+                "error": "Sequence was created but its ID could not be parsed as UUID; cannot add steps. Verify creation with rinda_sequence_list."
+            })
+            .to_string();
+        }
+    };
+
+    // Parse the JSON steps array.
+    let parsed_steps: serde_json::Value = match serde_json::from_str(&steps_json) {
+        Ok(v) => v,
+        Err(e) => {
+            return serde_json::json!({
+                "sequence": sequence_resp,
+                "sequence_id": sequence_id_str,
+                "error": format!("Sequence created but steps JSON is invalid: {e}")
+            })
+            .to_string();
+        }
+    };
+
+    let step_array = match parsed_steps.as_array() {
+        Some(a) => a.clone(),
+        None => {
+            return serde_json::json!({
+                "sequence": sequence_resp,
+                "sequence_id": sequence_id_str,
+                "error": "Sequence created but --steps must be a JSON array."
+            })
+            .to_string();
+        }
+    };
+
+    // Create each step via the API.
+    let mut step_results: Vec<serde_json::Value> = Vec::new();
+
+    for (idx, step) in step_array.iter().enumerate() {
+        let step_order_num = step
+            .get("stepOrder")
+            .or_else(|| step.get("step_order"))
+            .and_then(|v| v.as_f64())
+            .unwrap_or((idx + 1) as f64);
+
+        let delay_days_num = step
+            .get("delayDays")
+            .or_else(|| step.get("delay"))
+            .and_then(|v| v.as_f64())
+            .unwrap_or(1.0);
+
+        let subject_str = step
+            .get("emailSubject")
+            .or_else(|| step.get("subject"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("(no subject)");
+
+        let body_text = step
+            .get("emailBodyText")
+            .or_else(|| step.get("body"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let body_html = step
+            .get("emailBodyHtml")
+            .or_else(|| step.get("bodyHtml"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let subject_typed: rinda_sdk::types::PostApiV1SequencesByIdStepsBodyEmailSubject =
+            match subject_str.parse() {
+                Ok(s) => s,
+                Err(e) => {
+                    step_results.push(serde_json::json!({
+                        "step": idx + 1,
+                        "error": format!("Invalid email subject: {e}")
+                    }));
+                    continue;
+                }
+            };
+
+        let step_body = rinda_sdk::types::PostApiV1SequencesByIdStepsBody {
+            delay_days: rinda_sdk::types::PostApiV1SequencesByIdStepsBodyDelayDays::Number(
+                delay_days_num,
+            ),
+            email_body_html: body_html,
+            email_body_text: body_text,
+            email_subject: subject_typed,
+            email_template_id: None,
+            files: Vec::new(),
+            generation_source: None,
+            original_email_body_html: None,
+            original_email_body_text: None,
+            original_email_subject: None,
+            original_language: None,
+            scheduled_hour: None,
+            scheduled_minute: None,
+            step_order: rinda_sdk::types::PostApiV1SequencesByIdStepsBodyStepOrder::Number(
+                step_order_num,
+            ),
+            timezone: None,
+            translated_language: None,
+        };
+
+        match client
+            .post_api_v1_sequences_by_id_steps(&seq_uuid, &step_body)
+            .await
+        {
+            Ok(resp) => {
+                step_results.push(serde_json::json!({
+                    "step": idx + 1,
+                    "status": "created",
+                    "response": resp.into_inner()
+                }));
+            }
+            Err(e) => {
+                step_results.push(serde_json::json!({
+                    "step": idx + 1,
+                    "error": format!("step creation failed: {e}")
+                }));
+            }
         }
     }
+
+    serde_json::json!({
+        "sequence": sequence_resp,
+        "sequence_id": sequence_id_str,
+        "steps_created": step_results,
+        "message": format!(
+            "Sequence created with ID {}. {} step(s) processed.",
+            sequence_id_str.as_deref().unwrap_or("unknown"),
+            step_results.len()
+        )
+    })
+    .to_string()
 }
 
 /// List existing sequences for the workspace.
@@ -97,6 +284,196 @@ pub async fn sequence_generate(auth: &AuthContext, id: String) -> String {
         Err(e) => {
             serde_json::json!({ "error": format!("sequence generate failed: {e}") }).to_string()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: build a minimal AuthContext with a given workspace_id.
+    fn make_auth(workspace_id: &str) -> AuthContext {
+        AuthContext {
+            access_token: "test-token".to_string(),
+            workspace_id: workspace_id.to_string(),
+            user_id: "user-123".to_string(),
+            email: "test@example.com".to_string(),
+        }
+    }
+
+    /// Acceptance criteria from issue #124: empty workspace_id produces an explicit,
+    /// actionable error message mentioning re-authentication — NOT a confusing UUID error.
+    #[tokio::test]
+    async fn sequence_create_empty_workspace_id_returns_actionable_error() {
+        let auth = make_auth("");
+        let result = sequence_create(&auth, "Test Campaign".to_string(), None, None).await;
+        let json: serde_json::Value =
+            serde_json::from_str(&result).expect("result should be valid JSON");
+        let error = json["error"].as_str().expect("should have error field");
+        assert!(
+            error.contains("re-authenticate") || error.contains("workspace"),
+            "error should mention workspace or re-authentication: {error}"
+        );
+        // Must NOT produce a UUID parse error (the old confusing message).
+        assert!(
+            !error.contains("UUID") && !error.contains("uuid"),
+            "error should not mention UUID directly (that's the old confusing message): {error}"
+        );
+    }
+
+    /// Acceptance criteria from issue #124: invalid (non-UUID) workspace_id produces a
+    /// workspace-specific error, not a generic parse failure.
+    #[tokio::test]
+    async fn sequence_create_invalid_workspace_id_returns_workspace_error() {
+        let auth = make_auth("not-a-uuid");
+        let result = sequence_create(&auth, "Test Campaign".to_string(), None, None).await;
+        let json: serde_json::Value =
+            serde_json::from_str(&result).expect("result should be valid JSON");
+        let error = json["error"].as_str().expect("should have error field");
+        assert!(
+            error.contains("re-authenticate") || error.contains("workspace"),
+            "error should mention workspace or re-authentication: {error}"
+        );
+    }
+
+    /// Acceptance criteria: steps JSON that is not an array produces an error.
+    #[test]
+    fn steps_json_not_an_array_is_detected() {
+        let bad_steps = r#"{"delay": 1}"#; // object, not array
+        let parsed: serde_json::Value = serde_json::from_str(bad_steps).unwrap();
+        assert!(
+            parsed.as_array().is_none(),
+            "a JSON object should not parse as array"
+        );
+    }
+
+    /// Acceptance criteria: invalid steps JSON produces a parse error.
+    #[test]
+    fn steps_json_invalid_json_is_detected() {
+        let bad_steps = "not json at all";
+        let result: Result<serde_json::Value, _> = serde_json::from_str(bad_steps);
+        assert!(result.is_err(), "invalid JSON should fail to parse");
+    }
+
+    /// Acceptance criteria: valid steps JSON array is parsed correctly.
+    #[test]
+    fn steps_json_valid_array_parses_correctly() {
+        let steps = r#"[{"delay": 3, "subject": "Hello", "body": "Email body"}]"#;
+        let parsed: serde_json::Value = serde_json::from_str(steps).unwrap();
+        let arr = parsed.as_array().expect("should be an array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["delay"].as_f64(), Some(3.0));
+        assert_eq!(arr[0]["subject"].as_str(), Some("Hello"));
+        assert_eq!(arr[0]["body"].as_str(), Some("Email body"));
+    }
+
+    /// Acceptance criteria: step field aliases are recognized (delay vs delayDays, subject vs emailSubject).
+    #[test]
+    fn step_field_aliases_are_recognized() {
+        let steps = r#"[
+            {"delayDays": 2, "emailSubject": "Hi", "emailBodyText": "Body text"},
+            {"delay": 1, "subject": "Hello", "body": "Body"}
+        ]"#;
+        let parsed: serde_json::Value = serde_json::from_str(steps).unwrap();
+        let arr = parsed.as_array().expect("should be an array");
+
+        // First step uses canonical API names.
+        let s0 = &arr[0];
+        let delay = s0
+            .get("delayDays")
+            .or_else(|| s0.get("delay"))
+            .and_then(|v| v.as_f64())
+            .unwrap_or(1.0);
+        assert_eq!(delay, 2.0);
+        let subject = s0
+            .get("emailSubject")
+            .or_else(|| s0.get("subject"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("(no subject)");
+        assert_eq!(subject, "Hi");
+
+        // Second step uses shorthand aliases.
+        let s1 = &arr[1];
+        let delay2 = s1
+            .get("delayDays")
+            .or_else(|| s1.get("delay"))
+            .and_then(|v| v.as_f64())
+            .unwrap_or(1.0);
+        assert_eq!(delay2, 1.0);
+        let subject2 = s1
+            .get("emailSubject")
+            .or_else(|| s1.get("subject"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("(no subject)");
+        assert_eq!(subject2, "Hello");
+    }
+
+    /// Acceptance criteria: seq_type is forwarded as description with "Type: " prefix.
+    #[test]
+    fn seq_type_forwarded_as_description() {
+        let seq_type = Some("email".to_string());
+        let description = seq_type.map(|t| format!("Type: {t}"));
+        assert_eq!(description.as_deref(), Some("Type: email"));
+    }
+
+    /// Acceptance criteria: None seq_type produces None description (no spurious field).
+    #[test]
+    fn seq_type_none_produces_none_description() {
+        let seq_type: Option<String> = None;
+        let description = seq_type.map(|t| format!("Type: {t}"));
+        assert!(description.is_none());
+    }
+
+    /// Acceptance criteria: step_order defaults to 1-based index when not specified.
+    #[test]
+    fn step_order_defaults_to_index_plus_one() {
+        let steps = serde_json::json!([{"subject": "A"}, {"subject": "B"}]);
+        let arr = steps.as_array().unwrap();
+        for (idx, step) in arr.iter().enumerate() {
+            let order = step
+                .get("stepOrder")
+                .or_else(|| step.get("step_order"))
+                .and_then(|v| v.as_f64())
+                .unwrap_or((idx + 1) as f64);
+            assert_eq!(order, (idx + 1) as f64);
+        }
+    }
+
+    /// Acceptance criteria: created sequence ID is extracted from response `id` field.
+    #[test]
+    fn sequence_id_extracted_from_response() {
+        let resp: serde_json::Map<String, serde_json::Value> = serde_json::from_str(
+            r#"{"id": "550e8400-e29b-41d4-a716-446655440000", "name": "Test"}"#,
+        )
+        .unwrap();
+        let id = resp.get("id").and_then(|v| v.as_str());
+        assert_eq!(id, Some("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    /// Acceptance criteria: sequence ID is also found in nested `data.id` field.
+    #[test]
+    fn sequence_id_extracted_from_nested_data_field() {
+        let resp: serde_json::Map<String, serde_json::Value> = serde_json::from_str(
+            r#"{"data": {"id": "550e8400-e29b-41d4-a716-446655440000"}, "status": "ok"}"#,
+        )
+        .unwrap();
+        let id = resp
+            .get("id")
+            .or_else(|| resp.get("data").and_then(|d| d.get("id")))
+            .and_then(|v| v.as_str());
+        assert_eq!(id, Some("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    /// Acceptance criteria: missing ID field returns None (not a panic).
+    #[test]
+    fn sequence_id_missing_from_response_returns_none() {
+        let resp: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(r#"{"name": "Test"}"#).unwrap();
+        let id = resp
+            .get("id")
+            .or_else(|| resp.get("data").and_then(|d| d.get("id")))
+            .and_then(|v| v.as_str());
+        assert!(id.is_none());
     }
 }
 

--- a/plugins/rinda-ai/skills/rinda/SKILL.md
+++ b/plugins/rinda-ai/skills/rinda/SKILL.md
@@ -172,7 +172,11 @@ List existing sequences in the workspace. Optional: `--offset` for pagination.
 rinda-cli sequence create --name "Campaign Name"
 ```
 
-Optional: `--type "email"`, `--steps '[{"delay":1,"template":"intro"}]'`
+Optional: `--type "email"`, `--steps '[{"delay":1,"subject":"Subject line","body":"Email body text"}]'`
+
+The response includes the created sequence `id`. Verify creation with `rinda-cli sequence list`.
+
+Step object fields: `delay`/`delayDays` (days, default 1), `subject`/`emailSubject` (required), `body`/`emailBodyText`, `bodyHtml`/`emailBodyHtml`, `stepOrder`.
 
 ### Sequence Generate
 
@@ -227,10 +231,13 @@ rinda-cli order history --buyer-id "search term" --days-inactive 30
 
 1. `rinda-cli auth ensure-valid`
 2. `rinda-cli sequence list` → check existing sequences
-3. `rinda-cli sequence create --name "Name"` → get sequence ID
-4. `rinda-cli sequence generate --id "ID"` → AI-generate email steps
+3. `rinda-cli sequence create --name "Name" [--type "email"] [--steps '[...]']` → get sequence ID
+   - **Verify**: check that the response contains an `id` field. If `id` is missing, run `rinda-cli sequence list` to confirm the draft was persisted.
+   - If you pass `--steps`, each step is created immediately after the sequence; check per-step results in the output.
+4. `rinda-cli sequence generate --id "ID"` → AI-generate email steps (skip if you already provided `--steps`)
 5. For each lead: `rinda-cli sequence add-contact --sequence-id "ID" --buyer-id "ID"`
-6. Present summary, suggest: check replies later
+6. Confirm: `rinda-cli sequence list` → verify the new sequence appears
+7. Present summary, suggest: check replies later
 
 ### 4. Reply Management
 


### PR DESCRIPTION
## Problem / Task

When using `rinda_sequence_create`, the `seq_type` and `steps` parameters were silently discarded (`let _ = (seq_type, steps)`), resulting in empty sequences regardless of user input. Additionally, an empty `workspace_id` from the JWT produced a confusing UUID parse error, and there was no verification that the sequence was actually persisted.

**Current behavior:** Steps are dropped, empty workspace_id causes cryptic errors, no creation verification.
**Expected behavior:** Steps are forwarded to the steps API, empty workspace_id returns an actionable error, and the response includes the created sequence ID for verification.

Closes #124

## Existing Architecture

The MCP server and CLI both called `sequence_create` but immediately discarded the `seq_type` and `steps` parameters. The workspace_id was passed through without validation, causing downstream UUID parse failures.

```mermaid
graph TD
    A[Claude / User] --> B[MCP sequence_create]
    A --> C[CLI sequence create]
    B --> D["let _ = (seq_type, steps)"]
    D --> E[POST /sequences - name only]
    C --> F["_seq_type, _steps ignored"]
    F --> E
    E --> G[Empty sequence created]
    style D fill:#f66,stroke:#333
    style F fill:#f66,stroke:#333
```

## Proposed Architecture

Both MCP and CLI now forward `seq_type` as the sequence description and create steps via the steps API after sequence creation. Workspace ID is validated early with an actionable error message. The response includes the sequence ID for verification.

```mermaid
graph TD
    A[Claude / User] --> B[MCP sequence_create]
    A --> C[CLI sequence create]
    B --> V1[Validate workspace_id]
    C --> V2[Validate workspace_id]
    V1 --> D[POST /sequences + description]
    V2 --> D
    D --> E[Extract sequence ID]
    E --> F["POST /sequences/{id}/steps × N"]
    F --> G[Return ID + step results]
    style V1 fill:#6f6,stroke:#333
    style V2 fill:#6f6,stroke:#333
    style E fill:#69f,stroke:#333
    style F fill:#6f6,stroke:#333
    style G fill:#6f6,stroke:#333
```

## Key Changes

### 1. Steps forwarded via steps API
- Removed `let _ = (seq_type, steps)` — both parameters are now fully utilized
- `seq_type` is forwarded as the sequence `description` field (prefixed "Type: ")
- After sequence creation, each step in the JSON array is POSTed to `/api/v1/sequences/{id}/steps`
- Field aliases supported: `delay`/`delayDays`, `subject`/`emailSubject`, `body`/`emailBodyText`, `bodyHtml`/`emailBodyHtml`

### 2. Fail-fast on empty workspace_id
- MCP server checks `workspace_id` is non-empty before attempting UUID parse
- Returns actionable error: "No workspace ID found in your authentication token. Please re-authenticate..."
- Invalid (non-UUID) workspace_id also gets a clear message mentioning the specific value

### 3. Creation verification
- Response always includes `sequence_id` and `steps_created` array
- Warning emitted if sequence ID is not found in API response
- CLI prints per-step creation results

### 4. SKILL.md updated
- Added verification step (step 6) to the Email Sequence workflow
- Updated `--steps` field documentation with supported field names

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Unit Tests | ✅ | 139 passed, 0 failed |
| Clippy Lint | ✅ | 2 non-blocking warnings (items_after_test_module) |
| Build | ✅ | Compiles successfully |

12 new unit tests added covering:
- Empty/invalid workspace_id error messages
- Steps JSON parsing (valid array, invalid JSON, non-array)
- Field alias resolution
- seq_type forwarding as description
- Sequence ID extraction (top-level, nested data.id, missing)
- Step order defaulting

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP and CLI sequence creation to forward step data, validate workspace IDs early, and return the created sequence ID for verification. Resolves Linear #124 by preventing dropped steps and clarifying auth errors.

- **Bug Fixes**
  - Forward inputs: `seq_type` -> sequence `description`; steps created via `POST /api/v1/sequences/{id}/steps`.
  - Fail fast on empty or non-UUID `workspace_id` with clear re-auth guidance.
  - Return `sequence_id` for verification and warn if missing.

- **New Features**
  - CLI prints per-step results and exits non-zero if any step fails.
  - Step JSON supports aliases: `delay`/`delayDays`, `subject`/`emailSubject`, `body`/`emailBodyText`, `bodyHtml`/`emailBodyHtml`, `stepOrder`. Docs updated in `SKILL.md`.

<sup>Written for commit bc11ee690fc4df19a2d7dfc456b7e69faa1c4fae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sequences can now be created with steps in a single operation via CLI and API.
  * Enhanced step creation with support for field aliases (delay/delayDays, subject/emailSubject, body variants, stepOrder).
  * Improved error handling and validation for workspace IDs and step JSON parsing.

* **Documentation**
  * Updated sequence creation workflow with step structure details and verification guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->