### PR TITLE
fix(ci): use cross for aarch64-linux-musl to fix glibc link errors

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,6 +42,7 @@ jobs:
             os: ubuntu-latest
             artifact: rinda-cli-linux-arm64
             mcp_artifact: rinda-mcp-linux-arm64
+            use_cross: true
           - target: x86_64-apple-darwin
             os: macos-latest
             artifact: rinda-cli-macos-x64
@@ -74,11 +75,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools
 
-      - name: Install cross-compilation tools (Linux ARM64 musl)
-        if: matrix.target == 'aarch64-unknown-linux-musl'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu musl-tools
+      - name: Install cross
+        if: matrix.use_cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -86,14 +85,10 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Build release binary (rinda-cli)
-        run: cargo build --release --target ${{ matrix.target }} -p rinda-cli
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
+        run: ${{ matrix.use_cross && 'cross' || 'cargo' }} build --release --target ${{ matrix.target }} -p rinda-cli
 
       - name: Build release binary (rinda-mcp)
-        run: cargo build --release --target ${{ matrix.target }} -p rinda-mcp
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
+        run: ${{ matrix.use_cross && 'cross' || 'cargo' }} build --release --target ${{ matrix.target }} -p rinda-mcp
 
       - name: Rename binary (Unix)
         if: runner.os != 'Windows'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "rinda-cli"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "axum",
  "base64",


### PR DESCRIPTION
## Problem / Task

The `aarch64-unknown-linux-musl` release build fails during linking because `aws-lc-sys` (pulled in via `reqwest` → `rustls` → `aws-lc-rs`) is compiled with `aarch64-linux-gnu-gcc`, which produces objects referencing glibc-specific symbols (`__isoc23_sscanf`, `__fprintf_chk`, etc.) that don't exist in musl.

**Current behavior:** The CI build for `aarch64-unknown-linux-musl` fails with undefined reference errors to glibc symbols because the GNU cross-compiler (`gcc-aarch64-linux-gnu`) links against glibc, not musl.

**Expected behavior:** The `aarch64-unknown-linux-musl` target builds successfully using a proper musl cross-compilation toolchain.

## Existing Architecture

The CI workflow used `gcc-aarch64-linux-gnu` as both the linker and C compiler for the aarch64-musl target, which produced glibc-linked objects incompatible with musl.

```mermaid
graph TD
    A[release-please.yml] --> B[Build Matrix]
    B --> C[x86_64-linux-musl<br/>musl-tools ✅]
    B --> D[aarch64-linux-musl<br/>gcc-aarch64-linux-gnu ❌]
    B --> E[macOS / Windows targets]
    D --> F[aws-lc-sys compiled with GNU gcc]
    F --> G[Links glibc symbols 💥]
    style D fill:#f66,stroke:#333
    style F fill:#f66,stroke:#333
    style G fill:#f66,stroke:#333
```

## Proposed Architecture

Replaced the GNU cross-compiler with [`cross`](https://github.com/cross-rs/cross), which provides Docker-based musl cross-compilation toolchains with proper musl libc.

```mermaid
graph TD
    A[release-please.yml] --> B[Build Matrix]
    B --> C[x86_64-linux-musl<br/>musl-tools + cargo]
    B --> D[aarch64-linux-musl<br/>cross + Docker]
    B --> E[macOS / Windows targets]
    D --> F[aws-lc-sys compiled in musl container]
    F --> G[Links musl libc ✅]
    style D fill:#6f6,stroke:#333
    style F fill:#6f6,stroke:#333
    style G fill:#6f6,stroke:#333
```

## Key Changes

### Switch aarch64-musl build to use `cross`
- Added `use_cross: true` flag to the `aarch64-unknown-linux-musl` matrix entry
- Replaced `gcc-aarch64-linux-gnu` installation step with conditional `cross` installation (`cargo install cross`)
- Build commands now dynamically select `cross` or `cargo` via `${{ matrix.use_cross && 'cross' || 'cargo' }}`
- Removed `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER` env var — `cross` handles toolchain configuration internally
- All other targets (x86_64-musl, macOS, Windows) remain unchanged

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Unit Tests | ✅ | 6 passed, 0 failed |
| Clippy | ✅ | 2 pre-existing warnings (unrelated to this change) |
| Build | ✅ | Compiles successfully |

> **Note:** The actual CI fix can only be fully validated when the release workflow runs on GitHub Actions with the aarch64-musl target.

Closes #127

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `aarch64-unknown-linux-musl` CI release build by switching to `cross`, eliminating glibc link errors from `aws-lc-sys` and producing musl-linked binaries. Closes #127.

- **Bug Fixes**
  - Build `aarch64-unknown-linux-musl` with `cross` (`use_cross: true` + `cargo install cross`).
  - Removed `gcc-aarch64-linux-gnu` setup and `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER`; `cross` uses the musl toolchain via Docker.
  - Build steps now select `cross` or `cargo` with `${{ matrix.use_cross && 'cross' || 'cargo' }}`; other targets remain unchanged.

<sup>Written for commit ada35e75112adf738bca0ccb88d02751aba88e65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build infrastructure with enhanced cross-compilation support for ARM64 Linux targets using a unified approach.
  * Streamlined the release build pipeline by consolidating platform-specific steps into a flexible conditional strategy that enables consistent builds across different architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->