### PR TITLE
fix(mcp,cli): cargo fmt and clippy fixes for #130

### DIFF
--- a/crates/cli/src/oauth.rs
+++ b/crates/cli/src/oauth.rs
@@ -185,18 +185,18 @@ pub async fn run_oauth_flow() -> Result<Credentials> {
         .to_string();
 
     // If /auth/me didn't include workspaceId, fetch from /workspaces/user.
-    if workspace_id.is_empty() {
-        if let Ok(ws_resp) = authed_client.get_api_v1_workspaces_user().await {
-            let ws_data = ws_resp.into_inner();
-            workspace_id = ws_data
-                .get("data")
-                .and_then(|d| d.as_array())
-                .and_then(|arr| arr.first())
-                .and_then(|ws| ws.get("id"))
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-        }
+    if workspace_id.is_empty()
+        && let Ok(ws_resp) = authed_client.get_api_v1_workspaces_user().await
+    {
+        let ws_data = ws_resp.into_inner();
+        workspace_id = ws_data
+            .get("data")
+            .and_then(|d| d.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|ws| ws.get("id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
     }
 
     Ok(Credentials {

--- a/crates/mcp-server/src/oauth.rs
+++ b/crates/mcp-server/src/oauth.rs
@@ -278,10 +278,7 @@ impl OAuthState {
 // ── User profile helper ──────────────────────────────────────────────────────
 
 /// Build an authenticated SDK client for the given base URL and access token.
-fn authed_sdk_client(
-    base_url: &str,
-    access_token: &str,
-) -> Result<rinda_sdk::Client, String> {
+fn authed_sdk_client(base_url: &str, access_token: &str) -> Result<rinda_sdk::Client, String> {
     let auth_value = format!("Bearer {access_token}");
     let mut headers = reqwest::header::HeaderMap::new();
     headers.insert(
@@ -341,19 +338,19 @@ async fn fetch_user_profile(
         .to_string();
 
     // If /auth/me didn't include workspaceId, fetch from /workspaces/user.
-    if workspace_id.is_empty() {
-        if let Ok(ws_resp) = client.get_api_v1_workspaces_user().await {
-            let ws_data = ws_resp.into_inner();
-            // Response shape: { data: [ { id, name, ownerId, ... }, ... ] }
-            workspace_id = ws_data
-                .get("data")
-                .and_then(|d| d.as_array())
-                .and_then(|arr| arr.first())
-                .and_then(|ws| ws.get("id"))
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-        }
+    if workspace_id.is_empty()
+        && let Ok(ws_resp) = client.get_api_v1_workspaces_user().await
+    {
+        let ws_data = ws_resp.into_inner();
+        // Response shape: { data: [ { id, name, ownerId, ... }, ... ] }
+        workspace_id = ws_data
+            .get("data")
+            .and_then(|d| d.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|ws| ws.get("id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
     }
 
     Ok((workspace_id, user_id, email))
@@ -921,16 +918,16 @@ async fn handle_refresh_token_grant(state: Arc<OAuthState>, req: TokenRequest) -
         .to_string();
 
     // Fetch user profile from /auth/me to get workspace_id.
-    let (workspace_id, user_id, email) =
-        match fetch_user_profile(&state.base_url, &new_access).await {
-            Ok(profile) => profile,
-            Err(e) => {
-                eprintln!("Failed to fetch user profile during token refresh: {e}");
-                let ctx = crate::auth::extract_auth_context_from_jwt(&new_access)
-                    .unwrap_or_default();
-                (ctx.workspace_id, ctx.user_id, ctx.email)
-            }
-        };
+    let (workspace_id, user_id, email) = match fetch_user_profile(&state.base_url, &new_access)
+        .await
+    {
+        Ok(profile) => profile,
+        Err(e) => {
+            eprintln!("Failed to fetch user profile during token refresh: {e}");
+            let ctx = crate::auth::extract_auth_context_from_jwt(&new_access).unwrap_or_default();
+            (ctx.workspace_id, ctx.user_id, ctx.email)
+        }
+    };
 
     let session_token = state.create_session(
         new_access,

--- a/crates/mcp-server/tests/live_mcp.rs
+++ b/crates/mcp-server/tests/live_mcp.rs
@@ -141,7 +141,9 @@ async fn live_oauth_discovery() {
 
     // Authorization server metadata
     let resp: Value = client
-        .get(format!("{ALPHA_MCP}/.well-known/oauth-authorization-server"))
+        .get(format!(
+            "{ALPHA_MCP}/.well-known/oauth-authorization-server"
+        ))
         .send()
         .await
         .unwrap()
@@ -214,7 +216,10 @@ async fn live_mcp_initialize_and_tools_list() {
     .await;
     assert_eq!(status, 200, "initialize should return 200");
 
-    let init = events.iter().find(|v| v["id"] == 1).expect("no init response");
+    let init = events
+        .iter()
+        .find(|v| v["id"] == 1)
+        .expect("no init response");
     assert!(init["error"].is_null(), "init error: {:?}", init["error"]);
     assert_eq!(init["result"]["serverInfo"]["name"], "rinda-mcp");
 
@@ -354,10 +359,7 @@ async fn live_workspaces_user_returns_workspace_id() {
     let ws_id = workspaces[0]["id"]
         .as_str()
         .expect("workspace should have id");
-    assert!(
-        !ws_id.is_empty(),
-        "workspace id should not be empty"
-    );
+    assert!(!ws_id.is_empty(), "workspace id should not be empty");
     println!("Workspace ID from /workspaces/user: {ws_id}");
 }
 


### PR DESCRIPTION
## Summary

- Apply `cargo fmt` formatting to files changed in #130
- Fix clippy `collapsible-if` warnings by using `if … && let` chains

Fixes CI failure from #130.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy` — zero warnings
- [x] All 139 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply `cargo fmt` and fix `clippy` collapsible-if warnings (switch to `if` + `let` chains) in `crates/mcp-server` and `crates/cli`, restoring CI broken by #130. No functional changes.

<sup>Written for commit 3e7d909f4ddd510d777974015798d1287d06090f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal structure of OAuth authentication workflow with improved conditional logic and client configuration patterns.
  * Consolidated code patterns across token exchange and user profile operations.
* **Style**
  * Code formatting improvements in test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->